### PR TITLE
Removed Image import

### DIFF
--- a/tesserwrap/tesseract.py
+++ b/tesserwrap/tesseract.py
@@ -1,5 +1,4 @@
 from libtesserwrap import Tesserwrap
-import Image
 
 class tesseract(Tesserwrap):
     def __init__(self, datadir="", lang="eng"):


### PR DESCRIPTION
Hi there, nice work with the extension.
But the `import Image` fails for me. Is it really needed? And if so, shouldn't it be `from PIL import Image`? At least on my machine with Python 2.7, only the latter works.

However this import does not seem to be used in the file anyway, could that line be removed? (worksforme)
