### PR TITLE
Updated tobytes to tostring method as per latest PIL available on effbot...

### DIFF
--- a/tesserwrap/__init__.py
+++ b/tesserwrap/__init__.py
@@ -71,7 +71,7 @@ class Tesseract(object):
         if image.mode != "L":
             image = image.convert("L")
 
-        img_bytes = image.tobytes()
+        img_bytes = image.tostring()
         tr.Tesserwrap_SetImage(
             self.handle,
             img_bytes,                  # Image data

--- a/tesserwrap/__init__.py
+++ b/tesserwrap/__init__.py
@@ -71,7 +71,11 @@ class Tesseract(object):
         if image.mode != "L":
             image = image.convert("L")
 
-        img_bytes = image.tostring()
+        if hasattr(image, "tobytes"):
+            img_bytes = image.tobytes()
+        else:
+            img_bytes = image.tostring()
+            
         tr.Tesserwrap_SetImage(
             self.handle,
             img_bytes,                  # Image data


### PR DESCRIPTION
Hey,

I just installed latest PIL using easy_install and while calling ::

```
img = Image.open("test.png")
```

I was getting an AttributeError for tobyte() which seems to have been removed from `PIL Image module: https://bitbucket.org/effbot/pil-117/src/f356a1f64271e9d3206fcf9059492ba1c9e163d6/PIL/Image.py?at=default
