### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README
+++ b/README
@@ -2,5 +2,5 @@ Tesserwrap - Basic Tesseract API Wrapper for Python
 
 Tesserwrap is a project that allows simple bindings to Tesseract's API rather than executing the application manually each time.
 
-Docs: https://tesserwrap.readthedocs.org/en/latest/
+Docs: https://tesserwrap.readthedocs.io/en/latest/
 IRC: #tesserwrap on Freenode


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
